### PR TITLE
Fix: Could not convert to numeric

### DIFF
--- a/churn_library.py
+++ b/churn_library.py
@@ -119,7 +119,7 @@ def encoder_helper(dataframe, category_lst, response='Churn'):
     '''
 
     for category in category_lst:
-        category_means = dataframe.groupby(category).mean()[response]
+        category_means = dataframe.groupby(category).mean(numeric_only=True)[response]
         new_feature = category + '_' + response
         dataframe[new_feature] = dataframe[category].map(category_means)
 
@@ -145,13 +145,13 @@ def perform_feature_engineering(dataframe, response='Churn'):
     dataframe = encoder_helper(dataframe, cat_columns, response='Churn')
     y = dataframe[response]
     X = dataframe.drop(response, axis=1)
-    X = X['Customer_Age', 'Dependent_count', 'Months_on_book',
+    X = X[['Customer_Age', 'Dependent_count', 'Months_on_book',
              'Total_Relationship_Count', 'Months_Inactive_12_mon',
              'Contacts_Count_12_mon', 'Credit_Limit', 'Total_Revolving_Bal',
              'Avg_Open_To_Buy', 'Total_Amt_Chng_Q4_Q1', 'Total_Trans_Amt',
              'Total_Trans_Ct', 'Total_Ct_Chng_Q4_Q1', 'Avg_Utilization_Ratio',
              'Gender_Churn', 'Education_Level_Churn', 'Marital_Status_Churn', 
-             'Income_Category_Churn', 'Card_Category_Churn']
+             'Income_Category_Churn', 'Card_Category_Churn']]
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
     return X_train, X_test, y_train, y_test


### PR DESCRIPTION
The latest sklearn package sets the numeric_only=False, that is why you are getting this issue. You need to set it to True when you want to apply agg mean groupby on categorical features.